### PR TITLE
Add code and notes: testing navigation

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -5,6 +5,9 @@
       <entry key="All Tests">
         <State />
       </entry>
+      <entry key="Unit-Instrumented-Tests">
+        <State />
+      </entry>
     </value>
   </component>
 </project>

--- a/.idea/runConfigurations/Unit_Instrumented_Tests.xml
+++ b/.idea/runConfigurations/Unit_Instrumented_Tests.xml
@@ -1,0 +1,65 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit-Instrumented-Tests" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests">
+    <module name="TestApplication.app.androidTest" />
+    <option name="TESTING_TYPE" value="0" />
+    <option name="METHOD_NAME" value="" />
+    <option name="CLASS_NAME" value="" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="TEST_NAME_REGEX" value="" />
+    <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />
+    <option name="EXTRA_OPTIONS" value="" />
+    <option name="RETENTION_ENABLED" value="No" />
+    <option name="RETENTION_MAX_SNAPSHOTS" value="2" />
+    <option name="RETENTION_COMPRESS_SNAPSHOTS" value="false" />
+    <option name="CLEAR_LOGCAT" value="false" />
+    <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
+    <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
+    <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
+    <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
+    <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
+    <option name="DEBUGGER_TYPE" value="Auto" />
+    <Auto>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Auto>
+    <Hybrid>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Hybrid>
+    <Java>
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Java>
+    <Native>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Native>
+    <Profilers>
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Java/Kotlin Method Sample (legacy)" />
+      <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
+      <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
+    </Profilers>
+    <method v="2">
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Unit-Tests" run_configuration_type="GradleRunConfiguration" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Unit_Tests.xml
+++ b/.idea/runConfigurations/Unit_Tests.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit-Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--stacktrace" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":app:testDebugUnitTest" />
+          <option value="--tests" />
+          <option value="&quot;com.example.testapplication.*&quot;" />
+          <option value="--rerun" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <ForceTestExec>true</ForceTestExec>
+    <method v="2" />
+  </configuration>
+</component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,12 +17,12 @@ val properties = File(rootDir, "apikey.properties").inputStream().use {
 val apiKeyProperties = properties.getValue("PIXABAY_API_KEY") as String
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.testapplication"
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
         buildConfigField("String", "PIXABAY_API_KEY", apiKeyProperties)
@@ -49,6 +49,11 @@ android {
     }
 
     namespace = "com.example.testapplication"
+
+    buildFeatures {
+        viewBinding = true
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/app/src/androidTest/java/com/example/testapplication/ui/AddShoppingItemFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/testapplication/ui/AddShoppingItemFragmentTest.kt
@@ -1,0 +1,61 @@
+// AddShoppingItemFragmentTest.kt
+
+package com.example.testapplication.ui
+
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.example.testapplication.R
+import com.example.testapplication.launchFragmentInHiltContainer
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@MediumTest
+@HiltAndroidTest
+class AddShoppingItemFragmentTest {
+
+    @get:Rule
+    val hiltAndroidRule: HiltAndroidRule = HiltAndroidRule(this)
+
+    @Before
+    fun setUp() {
+        hiltAndroidRule.inject()
+    }
+
+    @Test
+    fun clickImageViewShoppingImage_navigateToImagePickFragment() {
+        val navController = mock(NavController::class.java)
+
+        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+            Navigation.setViewNavController(requireView(), navController)
+        }
+
+        onView(withId(R.id.imageViewShoppingImage)).perform(click())
+
+        verify(navController).navigate(
+            AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+        )
+    }
+
+    @Test
+    fun pressBackButton_popBackStack() {
+        val navController = mock(NavController::class.java)
+
+        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+            Navigation.setViewNavController(requireView(), navController)
+        }
+
+        pressBack()
+
+        verify(navController).popBackStack()
+    }
+}

--- a/app/src/androidTest/java/com/example/testapplication/ui/ShoppingFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/testapplication/ui/ShoppingFragmentTest.kt
@@ -1,0 +1,45 @@
+// ShoppingFragmentTest.kt
+
+package com.example.testapplication.ui
+
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.example.testapplication.R
+import com.example.testapplication.launchFragmentInHiltContainer
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@MediumTest
+@HiltAndroidTest
+class ShoppingFragmentTest {
+    @get:Rule
+    var hiltAndroidRule: HiltAndroidRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltAndroidRule.inject()
+    }
+
+    @Test
+    fun clickAddShoppingItemButton_navigateToAddShoppingItemFragment() {
+        val navController = mock(NavController::class.java)
+        launchFragmentInHiltContainer<ShoppingFragment> {
+            Navigation.setViewNavController(requireView(), navController)
+        }
+
+        onView(withId(R.id.fabAddShoppingItem)).perform(click())
+
+        verify(navController).navigate(
+            ShoppingFragmentDirections.actionShoppingFragmentToAddShoppingItemFragment()
+        )
+    }
+}

--- a/app/src/main/java/com/example/testapplication/ui/AddShoppingItemFragment.kt
+++ b/app/src/main/java/com/example/testapplication/ui/AddShoppingItemFragment.kt
@@ -1,18 +1,45 @@
-// ShoppingFragment.kt
+// AddShoppingItemFragment.kt
 package com.example.testapplication.ui
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentAddShoppingItemBinding
 
 class AddShoppingItemFragment : Fragment(R.layout.fragment_add_shopping_item) {
 
     lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentAddShoppingItemBinding: FragmentAddShoppingItemBinding? = null
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentAddShoppingItemBinding.bind(view)
+        fragmentAddShoppingItemBinding = binding
 
-        viewModel = ViewModelProvider(requireActivity()).get(ShoppingViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity())[ShoppingViewModel::class.java]
+
+        binding.imageViewShoppingImage.setOnClickListener {
+            findNavController().navigate(
+                AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+            )
+        }
+
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.setCurrentImageUrl("")
+                findNavController().popBackStack()
+            }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(callback)
+    }
+
+    override fun onDestroyView() {
+        fragmentAddShoppingItemBinding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/example/testapplication/ui/ImagePickFragment.kt
+++ b/app/src/main/java/com/example/testapplication/ui/ImagePickFragment.kt
@@ -1,4 +1,4 @@
-// ShoppingFragment.kt
+// ImagePickFragment.kt
 package com.example.testapplication.ui
 
 import android.os.Bundle

--- a/app/src/main/java/com/example/testapplication/ui/LicenseFragment.kt
+++ b/app/src/main/java/com/example/testapplication/ui/LicenseFragment.kt
@@ -1,4 +1,4 @@
-// ShoppingFragment.kt
+// LicenseFragment.kt
 package com.example.testapplication.ui
 
 import android.os.Bundle

--- a/app/src/main/java/com/example/testapplication/ui/ShoppingFragment.kt
+++ b/app/src/main/java/com/example/testapplication/ui/ShoppingFragment.kt
@@ -5,14 +5,31 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentShoppingBinding
 
 class ShoppingFragment : Fragment(R.layout.fragment_shopping) {
 
     lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentShoppingBinding: FragmentShoppingBinding? = null
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentShoppingBinding.bind(view)
+        fragmentShoppingBinding = binding
 
-        viewModel = ViewModelProvider(requireActivity()).get(ShoppingViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity())[ShoppingViewModel::class.java]
+
+        binding.fabAddShoppingItem.setOnClickListener {
+            findNavController().navigate(
+                ShoppingFragmentDirections.actionShoppingFragmentToAddShoppingItemFragment()
+            )
+        }
+    }
+
+    override fun onDestroyView() {
+        fragmentShoppingBinding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,5 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/nav_graph">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/shoppingFragment">
 
+    <fragment
+        android:id="@+id/shoppingFragment"
+        android:name="com.example.testapplication.ui.ShoppingFragment"
+        android:label="ShoppingFragment" >
+        <action
+            android:id="@+id/action_shoppingFragment_to_licenseFragment"
+            app:destination="@id/licenseFragment" />
+        <action
+            android:id="@+id/action_shoppingFragment_to_addShoppingItemFragment"
+            app:destination="@id/addShoppingItemFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/addShoppingItemFragment"
+        android:name="com.example.testapplication.ui.AddShoppingItemFragment"
+        android:label="AddShoppingItemFragment" >
+        <action
+            android:id="@+id/action_addShoppingItemFragment_to_imagePickFragment"
+            app:destination="@id/imagePickFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/imagePickFragment"
+        android:name="com.example.testapplication.ui.ImagePickFragment"
+        android:label="ImagePickFragment" />
+    <fragment
+        android:id="@+id/licenseFragment"
+        android:name="com.example.testapplication.ui.LicenseFragment"
+        android:label="LicenseFragment" />
 </navigation>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.2.0" apply false
-    id("com.android.library") version "8.2.0" apply false
+    id("com.android.application") version "8.2.1" apply false
+    id("com.android.library") version "8.2.1" apply false
     id("org.jetbrains.kotlin.android") version "1.8.0" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-android.defaults.buildfeatures.buildconfig=true
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library

--- a/notes/notes_Android_Testing_With_PL_9.md
+++ b/notes/notes_Android_Testing_With_PL_9.md
@@ -1,0 +1,327 @@
+# Notes: Android Testing with Phillip Lackner
+
+Course URL: [Android Testing with PL](https://www.youtube.com/playlist?list=PLQkwcJG4YTCSYJ13G4kVIJ10X5zisB2Lq)
+
+<!-- markdownlint-disable MD010 -->
+
+## Sections
+
+- [Notes: Android Testing with Phillip Lackner](#notes-android-testing-with-phillip-lackner)
+  - [Sections](#sections)
+  - [Notes](#notes)
+  - [Setup Android Navigation components](#setup-android-navigation-components)
+  - [Additional Information](#additional-information)
+  - [Errors](#errors)
+    - [Course](#course)
+    - [Screenshots](#screenshots)
+    - [Links](#links)
+  - [Notes template](#notes-template)
+
+## Notes
+
+## Setup Android Navigation components
+
+- Create a nav graph in `app/src/main/res/navigation/nav_graph.xml` using the UI.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/shoppingFragment">
+
+    <fragment
+        android:id="@+id/shoppingFragment"
+        android:name="com.example.testapplication.ui.ShoppingFragment"
+        android:label="ShoppingFragment" >
+        <action
+            android:id="@+id/action_shoppingFragment_to_licenseFragment"
+            app:destination="@id/licenseFragment" />
+        <action
+            android:id="@+id/action_shoppingFragment_to_addShoppingItemFragment"
+            app:destination="@id/addShoppingItemFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/addShoppingItemFragment"
+        android:name="com.example.testapplication.ui.AddShoppingItemFragment"
+        android:label="AddShoppingItemFragment" >
+        <action
+            android:id="@+id/action_addShoppingItemFragment_to_imagePickFragment"
+            app:destination="@id/imagePickFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/imagePickFragment"
+        android:name="com.example.testapplication.ui.ImagePickFragment"
+        android:label="ImagePickFragment" />
+    <fragment
+        android:id="@+id/licenseFragment"
+        android:name="com.example.testapplication.ui.LicenseFragment"
+        android:label="LicenseFragment" />
+</navigation>
+```
+
+- Modify `app/src/main/res/layout/activity_main.xml` to serve as the Navigation Host.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?><!--suppress LongLine -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.MainActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+
+```
+
+- Add navigation to `ShoppingFragment.kt`.
+
+```kotlin
+// ShoppingFragment.kt
+package com.example.testapplication.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentShoppingBinding
+
+class ShoppingFragment : Fragment(R.layout.fragment_shopping) {
+
+    lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentShoppingBinding: FragmentShoppingBinding? = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentShoppingBinding.bind(view)
+        fragmentShoppingBinding = binding
+
+        viewModel = ViewModelProvider(requireActivity())[ShoppingViewModel::class.java]
+
+        binding.fabAddShoppingItem.setOnClickListener {
+            findNavController().navigate(
+                ShoppingFragmentDirections.actionShoppingFragmentToAddShoppingItemFragment()
+            )
+        }
+    }
+
+    override fun onDestroyView() {
+        fragmentShoppingBinding = null
+        super.onDestroyView()
+    }
+}
+
+```
+
+- Add navigation to `AddShoppingItemFragment.kt`.
+- Add a callback to navigate back and remove any selected image urls.
+
+```kotlin
+// AddShoppingItemFragment.kt
+package com.example.testapplication.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentAddShoppingItemBinding
+
+class AddShoppingItemFragment : Fragment(R.layout.fragment_add_shopping_item) {
+
+    lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentAddShoppingItemBinding: FragmentAddShoppingItemBinding? = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentAddShoppingItemBinding.bind(view)
+        fragmentAddShoppingItemBinding = binding
+
+        viewModel = ViewModelProvider(requireActivity())[ShoppingViewModel::class.java]
+
+        binding.imageViewShoppingImage.setOnClickListener {
+            findNavController().navigate(
+                AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+            )
+        }
+
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.setCurrentImageUrl("")
+                findNavController().popBackStack()
+            }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(callback)
+    }
+
+    override fun onDestroyView() {
+        fragmentAddShoppingItemBinding = null
+        super.onDestroyView()
+    }
+}
+
+```
+
+- Generate a test class for `ShoppingFragment.kt` at `app/src/androidTest/java/com/example/testapplication/ui/ShoppingFragmentTest.kt`.
+- Create a test function `clickAddShoppingItemButton_navigateToAddShoppingItemFragment` that:
+  - sets up a mock `NavController` with `Mockito.mock`.
+  - sets the navigation controller with the mocked `NavController` object using `Navigation.setViewNavController`.
+  - clicks on the floating action button with `Espresso.onView(withId(...)).perform(click())`.
+  - verify that the navigation action succeeded with `Mockito.verify(navController).navigate(...)`.
+
+```kotlin
+// ShoppingFragmentTest.kt
+
+package com.example.testapplication.ui
+
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.example.testapplication.R
+import com.example.testapplication.launchFragmentInHiltContainer
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@MediumTest
+@HiltAndroidTest
+class ShoppingFragmentTest {
+    @get:Rule
+    var hiltAndroidRule: HiltAndroidRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltAndroidRule.inject()
+    }
+
+    @Test
+    fun clickAddShoppingItemButton_navigateToAddShoppingItemFragment() {
+        val navController = mock(NavController::class.java)
+        launchFragmentInHiltContainer<ShoppingFragment> {
+            Navigation.setViewNavController(requireView(), navController)
+        }
+
+        onView(withId(R.id.fabAddShoppingItem)).perform(click())
+
+        verify(navController).navigate(
+            ShoppingFragmentDirections.actionShoppingFragmentToAddShoppingItemFragment()
+        )
+    }
+}
+
+```
+
+- Generate a test class for `AddShoppingItemFragment.kt` at `app/src/androidTest/java/com/example/testapplication/ui/AddShoppingItemFragmentTest.kt`.
+- Create a test function `clickImageViewShoppingImage_navigateToImagePickFragment` that:
+  - sets up a mock `NavController` with `Mockito.mock`.
+  - sets the navigation controller with the mocked `NavController` object using `Navigation.setViewNavController`.
+  - clicks on the floating action button with `Espresso.onView(withId(...)).perform(click())`.
+  - verify that the navigation action succeeded with `Mockito.verify(navController).navigate(...)`.
+- Create a test function `pressBackButton_popBackStack` that:
+  - sets up a mock `NavController` with `Mockito.mock`.
+  - sets the navigation controller with the mocked `NavController` object using `Navigation.setViewNavController`.
+  - use `Espresso.pressBack` to press the back button to navigate back.
+  - verify that the back navigation succeeded with `Mockito.verify(navController).popBackStack()`
+
+```kotlin
+// AddShoppingItemFragment.kt
+package com.example.testapplication.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentAddShoppingItemBinding
+
+class AddShoppingItemFragment : Fragment(R.layout.fragment_add_shopping_item) {
+
+    lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentAddShoppingItemBinding: FragmentAddShoppingItemBinding? = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = FragmentAddShoppingItemBinding.bind(view)
+        fragmentAddShoppingItemBinding = binding
+
+        viewModel = ViewModelProvider(requireActivity())[ShoppingViewModel::class.java]
+
+        binding.imageViewShoppingImage.setOnClickListener {
+            findNavController().navigate(
+                AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+            )
+        }
+
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.setCurrentImageUrl("")
+                findNavController().popBackStack()
+            }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(callback)
+    }
+
+    override fun onDestroyView() {
+        fragmentAddShoppingItemBinding = null
+        super.onDestroyView()
+    }
+}
+
+```
+
+## Additional Information
+
+## Errors
+
+### Course
+
+### Screenshots
+
+### Links
+
+- .
+
+## Notes template
+
+```kotlin
+
+```
+
+```xml
+
+```
+
+![Text](./static/img/name.jpg)
+
+[y]
+[y]: <https://link.to.thing> "link title"
+
+[link title](https://link.to.thing)


### PR DESCRIPTION
Add code and notes for testing Android navigation with `Mockito` and `espresso` libraries.

This includes the following actions:

- create new notes file `notes_Android_Testing_With_PL_9.md`.
- update android application and library gradle plugins from `8.2.0` to `8.2.1`.
- migrate `BuildConfig` to Gradle build files and turn on `ViewBinding`.
- update `compileSdk` and `targetSdk` to `34`.
- create a navigation graph at `app/src/main/res/navigation/nav_graph.xml`.
- add file name comments to `ImagePickFragment.kt` and `LicenseFragment.kt` in `testapplication/ui/`.
- add new `runConfigurations` that allow you to run unit and instrumented tests in one go.