### PR TITLE
Add code and notes for testing image picking

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,9 +2,6 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="All Tests">
-        <State />
-      </entry>
       <entry key="Unit-Instrumented-Tests">
         <State />
       </entry>

--- a/LICENSE
+++ b/LICENSE
@@ -27,3 +27,4 @@ Version 2.0, January 2004. This is hosted at
 For details see:
     app/src/androidTest/java/com/example/testapplication/LiveDataTestUtil.kt
     app/src/test/java/com/example/testapplication/LiveDataTestUtil.kt
+    app/src/androidTest/java/com/example/testapplication/HiltExtension.kt

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,11 +120,13 @@ dependencies {
     // Fragments
     debugImplementation("androidx.fragment:fragment-testing:1.5.0")
 
-    // Core
+    // Testing Core
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.arch.core:core-testing:2.1.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:3.1.2")
     androidTestImplementation("androidx.arch.core:core-testing:2.1.0")
 
     // Truth library for help with assertions

--- a/app/src/androidTest/java/com/example/testapplication/HiltExtension.kt
+++ b/app/src/androidTest/java/com/example/testapplication/HiltExtension.kt
@@ -225,10 +225,12 @@
  * hosted at
  *      https://github.com/android/architecture-components-samples
  * Modifications copyright (C) 2023 Debabrata Bhattacharya:
- *      package declaration on line 235
- *      import on line 259
- *      argument addition on line 261
- *      code addition on line 276
+ *      package declaration on line 237
+ *      import on line 261
+ *      argument addition on line 263
+ *      argument data type change on line 265
+ *      code addition on line 279
+ *      data type cast on line 291
  */
 
 // ! The line immediately below this line has been modified
@@ -238,11 +240,11 @@ import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StyleRes
+import androidx.core.util.Preconditions
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.core.internal.deps.guava.base.Preconditions
 
 /**
  * launchFragmentInContainer from the androidx.fragment:fragment-testing library
@@ -259,7 +261,8 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
     @StyleRes themeResId: Int = androidx.fragment.testing.R.style.FragmentScenarioEmptyFragmentActivityTheme,
     // ! The line immediately below this line has been modified
     fragmentFactory: FragmentFactory? = null,
-    crossinline action: Fragment.() -> Unit = {}
+    // ! The line immediately below this line has been modified
+    crossinline action: T.() -> Unit = {}
 ) {
     val startActivityIntent = Intent.makeMainActivity(
         ComponentName(
@@ -284,6 +287,7 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
             .add(android.R.id.content, fragment, "")
             .commitNow()
 
-        fragment.action()
+        // ! The line immediately below this line has been modified
+        (fragment as T).action()
     }
 }

--- a/app/src/androidTest/java/com/example/testapplication/data/local/FakeLocalDataSourceAndroidTest.kt
+++ b/app/src/androidTest/java/com/example/testapplication/data/local/FakeLocalDataSourceAndroidTest.kt
@@ -1,0 +1,43 @@
+// FakeLocalDataSource.kt
+package com.example.testapplication.data.local
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
+class FakeLocalDataSourceAndroidTest : LocalDataSource {
+
+    private val shoppingItems = mutableListOf<ShoppingItem>()
+    private val observableShoppingItems = MutableLiveData<List<ShoppingItem>>(shoppingItems)
+    private val observableTotalPrice = MutableLiveData<Double>()
+
+    private fun refreshLiveData() {
+        observableShoppingItems.postValue(shoppingItems)
+        observableTotalPrice.postValue(getTotalPrice())
+    }
+
+    private fun getTotalPrice(): Double {
+        return shoppingItems.sumOf { it.price }
+    }
+
+    override suspend fun createShoppingItem(item: ShoppingItem) {
+        shoppingItems.add(item)
+        refreshLiveData()
+    }
+
+    override suspend fun deleteShoppingItem(item: ShoppingItem): Int {
+        if (shoppingItems.remove(item)) {
+            refreshLiveData()
+            return 1
+        }
+        return 0
+    }
+
+    override fun observeAllShoppingItems(): LiveData<List<ShoppingItem>> {
+        return observableShoppingItems
+    }
+
+    override fun observeTotalPrice(): LiveData<Double> {
+        return observableTotalPrice
+    }
+
+}

--- a/app/src/androidTest/java/com/example/testapplication/data/remote/FakeRemoteDataSourceAndroidTest.kt
+++ b/app/src/androidTest/java/com/example/testapplication/data/remote/FakeRemoteDataSourceAndroidTest.kt
@@ -1,0 +1,29 @@
+// FakeRemoteDataSourceAndroidTest.kt
+package com.example.testapplication.data.remote
+
+import com.example.testapplication.Message
+import com.example.testapplication.Resource
+import com.example.testapplication.data.remote.response.ImageResponse
+
+class FakeRemoteDataSourceAndroidTest : RemoteDataSource {
+    private var networkError = NetworkErrors.NONE
+    fun setNetworkError(error: NetworkErrors) {
+        networkError = error
+    }
+
+    override suspend fun searchImages(
+        searchQuery: String, imageType: String?
+    ): Resource<ImageResponse> {
+        if (networkError.equals(NetworkErrors.NETWORK_UNREACHABLE)) {
+            @Suppress("HardCodedStringLiteral") return Resource.error(
+                Message("Error encountered while attempting to request API."), null
+            )
+        }
+        return Resource.success(ImageResponse(listOf(), 0, 0))
+    }
+}
+
+enum class NetworkErrors {
+    NONE, NETWORK_UNREACHABLE
+
+}

--- a/app/src/androidTest/java/com/example/testapplication/ui/ImagePickFragmentTest.kt
+++ b/app/src/androidTest/java/com/example/testapplication/ui/ImagePickFragmentTest.kt
@@ -1,13 +1,12 @@
-// AddShoppingItemFragmentTest.kt
+// ImagePickFragmentTest.kt
 
-package com.example.testapplication.ui
-
+package com.example.testapplication.ui // JUnit4 Test Class.java.java
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.filters.MediumTest
 import com.example.testapplication.R
@@ -24,66 +23,64 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import javax.inject.Inject
 
 @MediumTest
 @HiltAndroidTest
-class AddShoppingItemFragmentTest {
-
+class ImagePickFragmentTest {
     @get:Rule
     val instantTaskExecutorRule: InstantTaskExecutorRule = InstantTaskExecutorRule()
 
     @get:Rule
     val hiltAndroidRule: HiltAndroidRule = HiltAndroidRule(this)
 
+    @Inject
+    lateinit var fragmentFactory: ShoppingFragmentFactory
+
+    private val imageURL: String =
+        "https://blog.cloudflare.com/content/images/2021/09/image1-10.png"
+
     @Before
-    fun setUp() {
+    fun setup() {
         hiltAndroidRule.inject()
     }
 
     @Test
-    fun clickImageViewShoppingImage_navigateToImagePickFragment() {
+    fun clickImage_popBackStack() {
         val navController = mock(NavController::class.java)
 
-        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+        launchFragmentInHiltContainer<ImagePickFragment>(fragmentFactory = fragmentFactory) {
             Navigation.setViewNavController(requireView(), navController)
+            imageAdapter.images = listOf(imageURL)
         }
 
-        onView(withId(R.id.imageViewShoppingImage)).perform(click())
-
-        verify(navController).navigate(
-            AddShoppingItemFragmentDirections.actionAddShoppingItemFragmentToImagePickFragment()
+        onView(withId(R.id.recyclerViewImages)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<ImageAdapter.ImageViewHolder>(0, click())
         )
-    }
-
-    @Test
-    fun pressBackButton_popBackStack() {
-        val navController = mock(NavController::class.java)
-
-        launchFragmentInHiltContainer<AddShoppingItemFragment> {
-            Navigation.setViewNavController(requireView(), navController)
-        }
-
-        pressBack()
 
         verify(navController).popBackStack()
     }
 
     @Test
-    fun pressBackButton_setBlankImageUrl() {
+    fun clickImage_setImageURL() {
+        val navController = mock(NavController::class.java)
         val testViewModel = ShoppingViewModel(
             DefaultShoppingRepository(
-                FakeRemoteDataSourceAndroidTest(), FakeLocalDataSourceAndroidTest()
+                FakeRemoteDataSourceAndroidTest(),
+                FakeLocalDataSourceAndroidTest()
             )
         )
-        val navController = mock(NavController::class.java)
 
-        launchFragmentInHiltContainer<AddShoppingItemFragment> {
+        launchFragmentInHiltContainer<ImagePickFragment>(fragmentFactory = fragmentFactory) {
             Navigation.setViewNavController(requireView(), navController)
             viewModel = testViewModel
+            imageAdapter.images = listOf(imageURL)
         }
 
-        pressBack()
+        onView(withId(R.id.recyclerViewImages)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<ImageAdapter.ImageViewHolder>(0, click())
+        )
 
-        assertThat(testViewModel.currentImageUrl.getOrAwaitValue()).isEqualTo("")
+        assertThat(testViewModel.currentImageUrl.getOrAwaitValue()).isEqualTo(imageURL)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".ShoppingApplication"

--- a/app/src/main/java/com/example/testapplication/AppModule.kt
+++ b/app/src/main/java/com/example/testapplication/AppModule.kt
@@ -2,6 +2,9 @@ package com.example.testapplication
 
 import android.content.Context
 import androidx.room.Room
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
+import com.bumptech.glide.request.RequestOptions
 import com.example.testapplication.Constants.DATABASE_NAME
 import com.example.testapplication.Constants.PIXABAY_BASE_URL
 import com.example.testapplication.data.local.DefaultLocalDataSource
@@ -93,4 +96,17 @@ object AppModule {
     ): ShoppingRepository {
         return DefaultShoppingRepository(remoteDataSource, localDataSource)
     }
+
+    /**
+     * Provides a [Glide] instance [RequestManager] configured to load images.
+     */
+    @Singleton
+    @Provides
+    fun provideGlideInstance(
+        @ApplicationContext context: Context
+    ): RequestManager = Glide.with(context).setDefaultRequestOptions(
+        RequestOptions()
+            .placeholder(R.drawable.ic_image)
+            .error(R.drawable.ic_image)
+    )
 }

--- a/app/src/main/java/com/example/testapplication/Constants.kt
+++ b/app/src/main/java/com/example/testapplication/Constants.kt
@@ -16,4 +16,5 @@ object Constants {
     const val PIXABAY_BASE_URL: String = "https://pixabay.com"
     const val SHOPPING_ITEM_NAME_LENGTH: Int = 25
     const val SHOPPING_ITEM_PRICE_LENGTH: Int = 10
+    const val GRID_SPAN_COUNT: Int = 3
 }

--- a/app/src/main/java/com/example/testapplication/GlideModule.kt
+++ b/app/src/main/java/com/example/testapplication/GlideModule.kt
@@ -1,0 +1,12 @@
+// GlideModule.kt
+package com.example.testapplication
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+/**
+ * Used by Glide as a replacement for com.bumptech.glide.Glide in Applications that depend on
+ * Glide's generated code.
+ */
+@GlideModule
+class GlideModule : AppGlideModule()

--- a/app/src/main/java/com/example/testapplication/ui/ImageAdapter.kt
+++ b/app/src/main/java/com/example/testapplication/ui/ImageAdapter.kt
@@ -1,0 +1,65 @@
+// ImageAdapter.kt
+@file:Suppress("KDocMissingDocumentation")
+
+package com.example.testapplication.ui
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.RequestManager
+import com.example.testapplication.databinding.ItemImageBinding
+import javax.inject.Inject
+
+class ImageAdapter @Inject constructor(
+    private val glide: RequestManager
+) : RecyclerView.Adapter<ImageAdapter.ImageViewHolder>() {
+
+    class ImageViewHolder(val itemImageBinding: ItemImageBinding) :
+        RecyclerView.ViewHolder(itemImageBinding.root)
+
+    private val diffCallback = object : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    private val differ = AsyncListDiffer(this, diffCallback)
+
+    var images: List<String>
+        get() = differ.currentList
+        set(value) = differ.submitList(value)
+
+    private var onItemClickListener: ((String) -> Unit)? = null
+
+    fun setOnItemClickListener(listener: (String) -> Unit) {
+        onItemClickListener = listener
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageViewHolder {
+        return ImageViewHolder(
+            ItemImageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun getItemCount(): Int {
+        return images.size
+    }
+
+    override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
+        val url = images[position]
+        holder.itemView.apply {
+            glide.load(url).into(holder.itemImageBinding.imageViewShoppingImage)
+            setOnClickListener {
+                onItemClickListener?.let { click ->
+                    click(url)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/testapplication/ui/ImagePickFragment.kt
+++ b/app/src/main/java/com/example/testapplication/ui/ImagePickFragment.kt
@@ -5,14 +5,45 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.testapplication.Constants.GRID_SPAN_COUNT
 import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentImagePickBinding
+import javax.inject.Inject
 
-class ImagePickFragment : Fragment(R.layout.fragment_image_pick) {
+class ImagePickFragment @Inject constructor(
+    val imageAdapter: ImageAdapter
+) : Fragment(R.layout.fragment_image_pick) {
 
     lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentImagePickBinding: FragmentImagePickBinding? = null
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val binding: FragmentImagePickBinding = FragmentImagePickBinding.bind(view)
+        fragmentImagePickBinding = binding
 
         viewModel = ViewModelProvider(requireActivity()).get(ShoppingViewModel::class.java)
+
+        imageAdapter.setOnItemClickListener { url ->
+            findNavController().popBackStack()
+            viewModel.setCurrentImageUrl(url = url)
+        }
+
+        setupRecyclerView()
     }
+
+    override fun onDestroyView() {
+        fragmentImagePickBinding = null
+        super.onDestroyView()
+    }
+
+    private fun setupRecyclerView() {
+        fragmentImagePickBinding?.recyclerViewImages?.apply {
+            adapter = imageAdapter
+            layoutManager = GridLayoutManager(requireContext(), GRID_SPAN_COUNT)
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/testapplication/ui/ShoppingFragmentFactory.kt
+++ b/app/src/main/java/com/example/testapplication/ui/ShoppingFragmentFactory.kt
@@ -1,0 +1,17 @@
+// FragmentFactory.kt
+package com.example.testapplication.ui
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import javax.inject.Inject
+
+class ShoppingFragmentFactory @Inject constructor(
+    private val imageAdapter: ImageAdapter
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return when (className) {
+            ImagePickFragment::class.java.name -> ImagePickFragment(imageAdapter)
+            else -> return super.instantiate(classLoader, className)
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.2.1" apply false
-    id("com.android.library") version "8.2.1" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.0" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false
 }

--- a/notes/notes_Android_Testing_With_PL_10.md
+++ b/notes/notes_Android_Testing_With_PL_10.md
@@ -1,0 +1,580 @@
+# Notes: Android Testing with Phillip Lackner
+
+Course URL: [Android Testing with PL](https://www.youtube.com/playlist?list=PLQkwcJG4YTCSYJ13G4kVIJ10X5zisB2Lq)
+
+<!-- markdownlint-disable MD010 -->
+
+## Sections
+
+- [Notes: Android Testing with Phillip Lackner](#notes-android-testing-with-phillip-lackner)
+  - [Sections](#sections)
+  - [Notes](#notes)
+  - [Glide instance injection](#glide-instance-injection)
+  - [Setup `ImagePickFragment.kt`](#setup-imagepickfragmentkt)
+  - [Create an Adapter class](#create-an-adapter-class)
+  - [Create a FragmentFactory](#create-a-fragmentfactory)
+  - [Setup `ImagePickFragment`](#setup-imagepickfragment)
+  - [Test `ImagePickFragment`](#test-imagepickfragment)
+  - [Additional Information](#additional-information)
+    - [Errors](#errors)
+      - [Espresso tests fail if another area is in focus](#espresso-tests-fail-if-another-area-is-in-focus)
+    - [Screenshots](#screenshots)
+    - [Links](#links)
+  - [Notes template](#notes-template)
+
+## Notes
+
+## Glide instance injection
+
+Create a function to provide a Glide instance through dependency injection.
+
+- Add the `INTERNET` permission to the app manifest `app/src/main/AndroidManifest.xml` to allow Glide to load images from the internet.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".ShoppingApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.TestApplication">
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+```
+
+- Create a `AppGlideModule` class.
+
+```kotlin
+// GlideModule.kt
+package com.example.testapplication
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+/**
+ * Used by Glide as a replacement for com.bumptech.glide.Glide in Applications that depend on
+ * Glide's generated code.
+ */
+@GlideModule
+class GlideModule : AppGlideModule()
+
+```
+
+- Create a `RequestManager` with default `RequestOptions` for placeholder and error states.
+
+```kotlin
+package com.example.testapplication
+
+import android.content.Context
+import androidx.room.Room
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
+import com.bumptech.glide.request.RequestOptions
+import com.example.testapplication.Constants.DATABASE_NAME
+import com.example.testapplication.Constants.PIXABAY_BASE_URL
+import com.example.testapplication.data.local.DefaultLocalDataSource
+import com.example.testapplication.data.local.LocalDataSource
+import com.example.testapplication.data.local.ShoppingDao
+import com.example.testapplication.data.local.ShoppingListDatabase
+import com.example.testapplication.data.remote.DefaultRemoteDataSource
+import com.example.testapplication.data.remote.PixabayAPI
+import com.example.testapplication.data.remote.RemoteDataSource
+import com.example.testapplication.repository.DefaultShoppingRepository
+import com.example.testapplication.repository.ShoppingRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+/**
+ * Dependency injection module for objects that will live for the entire lifetime of the
+ * application.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    /**
+     * Provides the app database [ShoppingListDatabase].
+     */
+    @Singleton
+    @Provides
+    fun provideShoppingListDatabase(
+        @ApplicationContext context: Context
+    ): ShoppingListDatabase =
+        Room.databaseBuilder(context, ShoppingListDatabase::class.java, DATABASE_NAME).build()
+
+    /**
+     * Provides the DAO [ShoppingDao] for the [ShoppingListDatabase]
+     */
+    @Singleton
+    @Provides
+    fun provideShoppingDao(
+        database: ShoppingListDatabase
+    ): ShoppingDao = database.shoppingDao()
+
+    /**
+     * Provides the [PixabayAPI] Retrofit instance.
+     */
+    @Singleton
+    @Provides
+    fun providePixabayAPI(): PixabayAPI {
+        return Retrofit.Builder().addConverterFactory(GsonConverterFactory.create()).baseUrl(
+            PIXABAY_BASE_URL
+        ).build().create(PixabayAPI::class.java)
+    }
+
+    /**
+     * Provides the [RemoteDataSource] implementation instance.
+     */
+    @Singleton
+    @Provides
+    fun provideRemoteDataSource(
+        pixabayAPI: PixabayAPI
+    ): RemoteDataSource {
+        return DefaultRemoteDataSource(pixabayAPI)
+    }
+
+    /**
+     * Provides the [LocalDataSource] implementation instance.
+     */
+    @Singleton
+    @Provides
+    fun provideLocalDataSource(
+        shoppingDao: ShoppingDao
+    ): LocalDataSource {
+        return DefaultLocalDataSource(shoppingDao)
+    }
+
+    /**
+     * Provides an [ShoppingRepository] implementation in [DefaultShoppingRepository].
+     */
+    @Singleton
+    @Provides
+    fun provideDefaultShoppingRepository(
+        remoteDataSource: RemoteDataSource,
+        localDataSource: LocalDataSource
+    ): ShoppingRepository {
+        return DefaultShoppingRepository(remoteDataSource, localDataSource)
+    }
+
+    /**
+     * Provides a [Glide] instance [RequestManager] configured to load images.
+     */
+    @Singleton
+    @Provides
+    fun provideGlideInstance(
+        @ApplicationContext context: Context
+    ): RequestManager = Glide.with(context).setDefaultRequestOptions(
+        RequestOptions()
+            .placeholder(R.drawable.ic_image)
+            .error(R.drawable.ic_image)
+    )
+}
+
+
+```
+
+## Setup `ImagePickFragment.kt`
+
+- Setup the `RecyclerView` and `Adapter` classes.
+
+## Create an Adapter class
+
+- Inject he glide instance in the constructor of the `RecyclerView.Adapter` class.
+- Subclass a `ViewHolder` class with the `RecyclerView` item binding as an argument for `itemView`. Use `.root` on the binding to return the outermost view.
+- Create a `DiffUtil.ItemCallback` object to calculate the item difference between versions of the list passed to `RecyclerView` to trigger minimal animations and updates for a performant UI. From [RecyclerView] documentation: "This approach requires that each list is represented in memory with immutable content, and relies on receiving updates as new instances of lists. This approach is also ideal if your UI layer doesn't implement sorting, it just presents the data in the order it's given." And from [DiffUtil] documentation: "new lists should be provided any time content changes".
+- Create an [AsyncListDiffer] to help compute the `DiffUtil.ItemCallback` using a background thread.
+- Create a list to store image urls, and set the `get` and `set` methods to use the `AsyncListDiffer` instance methods.
+- Create a lambda function nullable variable `onItemClickListener` that takes a string as an argument. We create a function to set the listener from an adapter instance. This will allow us to set the listener from the UI layer.
+- Override the `onCreateViewHolder`, `getItemCount`, `onBindViewHolder` functions as usual.
+- In `onBindViewHolder` load the image from the url using Glide and set an on click listener.
+
+```kotlin
+// ImageAdapter.kt
+@file:Suppress("KDocMissingDocumentation")
+
+package com.example.testapplication.ui
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.RequestManager
+import com.example.testapplication.databinding.ItemImageBinding
+import javax.inject.Inject
+
+class ImageAdapter @Inject constructor(
+    private val glide: RequestManager
+) : RecyclerView.Adapter<ImageAdapter.ImageViewHolder>() {
+
+    class ImageViewHolder(val itemImageBinding: ItemImageBinding) :
+        RecyclerView.ViewHolder(itemImageBinding.root)
+
+    private val diffCallback = object : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    private val differ = AsyncListDiffer(this, diffCallback)
+
+    var images: List<String>
+        get() = differ.currentList
+        set(value) = differ.submitList(value)
+
+    private var onItemClickListener: ((String) -> Unit)? = null
+
+    fun setOnItemClickListener(listener: (String) -> Unit) {
+        onItemClickListener = listener
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageViewHolder {
+        return ImageViewHolder(
+            ItemImageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun getItemCount(): Int {
+        return images.size
+    }
+
+    override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
+        val url = images[position]
+        holder.itemView.apply {
+            glide.load(url).into(holder.itemImageBinding.imageViewShoppingImage)
+            setOnClickListener {
+                onItemClickListener?.let { click ->
+                    click(url)
+                }
+            }
+        }
+    }
+}
+
+```
+
+## Create a FragmentFactory
+
+- We modify the constructor of `ImagePickFragment` to accept an `ImageAdapter` as a val.
+
+```kotlin
+// ImagePickFragment.kt
+package com.example.testapplication.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.testapplication.Constants.GRID_SPAN_COUNT
+import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentImagePickBinding
+import javax.inject.Inject
+
+class ImagePickFragment @Inject constructor(
+    private val imageAdapter: ImageAdapter
+) : Fragment(R.layout.fragment_image_pick)
+```
+
+- We create a `FragmentFactory` to perform constructor injection in our fragments. We do this instead of field injection to be able to easily create fragments with dependency injection, without having to set it up. This follows the dependency inversion principle. This also aids in testing fragments.
+- We override the `instantiate` method to return a custom `ImagePickFragment` with an `ImageAdapter` in the constructor.
+
+```kotlin
+// FragmentFactory.kt
+package com.example.testapplication.ui
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import javax.inject.Inject
+
+class ShoppingFragmentFactory @Inject constructor(
+    private val imageAdapter: ImageAdapter
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return when (className) {
+            ImagePickFragment::class.java.name -> ImagePickFragment(imageAdapter)
+            else -> return super.instantiate(classLoader, className)
+        }
+    }
+}
+
+```
+
+## Setup `ImagePickFragment`
+
+- Setup view binding.
+- Create a constant `GRID_SPAN_COUNT` for `GridLayoutManager` spans.
+
+```kotlin
+// Constants.kt
+package com.example.testapplication
+
+/**
+ * Object instance that encapsulates constant values
+ * throughout the application.
+ *
+ * @property[DATABASE_NAME] Name of the Room database for the application.
+ * @property[PIXABAY_BASE_URL] Base Pixabay API URL.
+ * @property[SHOPPING_ITEM_NAME_LENGTH] Max length of name field in `ShoppingItem`.
+ * @property[SHOPPING_ITEM_PRICE_LENGTH] Max length of price field in `ShoppingItem`.
+ */
+@Suppress("HardCodedStringLiteral", "MemberVisibilityCanBePrivate")
+object Constants {
+    const val DATABASE_NAME: String = "shopping_db"
+    const val PIXABAY_BASE_URL: String = "https://pixabay.com"
+    const val SHOPPING_ITEM_NAME_LENGTH: Int = 25
+    const val SHOPPING_ITEM_PRICE_LENGTH: Int = 10
+    const val GRID_SPAN_COUNT: Int = 3
+}
+
+```
+
+- Set `setOnItemClickListener` for the `ImageAdapter` instance to set an image url and navigate back.
+- Create a private function `setupRecyclerView` and call it.
+
+```kotlin
+// ImagePickFragment.kt
+package com.example.testapplication.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
+import com.example.testapplication.Constants.GRID_SPAN_COUNT
+import com.example.testapplication.R
+import com.example.testapplication.databinding.FragmentImagePickBinding
+import javax.inject.Inject
+
+class ImagePickFragment @Inject constructor(
+    private val imageAdapter: ImageAdapter
+) : Fragment(R.layout.fragment_image_pick) {
+
+    lateinit var viewModel: ShoppingViewModel
+
+    private var fragmentImagePickBinding: FragmentImagePickBinding? = null
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding: FragmentImagePickBinding = FragmentImagePickBinding.bind(view)
+        fragmentImagePickBinding = binding
+
+        viewModel = ViewModelProvider(requireActivity()).get(ShoppingViewModel::class.java)
+
+        imageAdapter.setOnItemClickListener { url ->
+            findNavController().popBackStack()
+            viewModel.setCurrentImageUrl(url = url)
+        }
+
+        setupRecyclerView()
+    }
+
+    override fun onDestroyView() {
+        fragmentImagePickBinding = null
+        super.onDestroyView()
+    }
+
+    private fun setupRecyclerView() {
+        fragmentImagePickBinding?.recyclerViewImages?.apply {
+            adapter = imageAdapter
+            layoutManager = GridLayoutManager(requireContext(), GRID_SPAN_COUNT)
+        }
+    }
+
+}
+
+```
+
+## Test `ImagePickFragment`
+
+- Add the libraries `espresso-contrib` to `app/build.gradle.kts`.
+
+```kotlin
+    // Testing Core
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.arch.core:core-testing:2.1.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.3")
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:3.1.2")
+    androidTestImplementation("androidx.arch.core:core-testing:2.1.0")
+```
+
+- Generate `app/src/androidTest/java/com/example/testapplication/ui/ImagePickFragmentTest.kt`.
+- Create a test function `clickImage_popBackStack` that:
+  - sets up a mock `NavController` with `Mockito.mock`.
+  - sets the test url to an image that loads fast and passes it to the adapter.
+  - sets the navigation controller with the mocked `NavController` object using `Navigation.setViewNavController`.
+  - clicks on the first item in the recycler view with `Espresso.onView(withId(...)).perform(RecyclerViewActions.actionOnItemAtPosition<...>(0, click()))`.
+  - verify that the navigation action succeeded with `Mockito.verify(navController).navigate(...)`.
+- Create a test function `clickImage_setImageURL` that:
+  - sets up a mock `NavController` with `Mockito.mock`.
+  - sets up a `viewModel` instance that uses fake data sources to speed up the test.
+  - sets the navigation controller with the mocked `NavController` object using `Navigation.setViewNavController`.
+  - sets the test url to an image that loads fast and passes it to the adapter.
+  - sets the `viewModel` to the test `viewModel` instance.
+  - clicks on the first item in the recycler view with `Espresso.onView(withId(...)).perform(RecyclerViewActions.actionOnItemAtPosition<...>(0, click()))`.
+  - asserts that the `currentImageUrl` in the test `viewModel` instance has been set to the test url.
+
+```kotlin
+// ImagePickFragmentTest.kt
+
+package com.example.testapplication.ui // JUnit4 Test Class.java.java
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.filters.MediumTest
+import com.example.testapplication.R
+import com.example.testapplication.data.local.FakeLocalDataSourceAndroidTest
+import com.example.testapplication.data.remote.FakeRemoteDataSourceAndroidTest
+import com.example.testapplication.getOrAwaitValue
+import com.example.testapplication.launchFragmentInHiltContainer
+import com.example.testapplication.repository.DefaultShoppingRepository
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import javax.inject.Inject
+
+@MediumTest
+@HiltAndroidTest
+class ImagePickFragmentTest {
+    @get:Rule
+    val instantTaskExecutorRule: InstantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val hiltAndroidRule: HiltAndroidRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var fragmentFactory: ShoppingFragmentFactory
+
+    private val imageURL: String =
+        "https://blog.cloudflare.com/content/images/2021/09/image1-10.png"
+
+    @Before
+    fun setup() {
+        hiltAndroidRule.inject()
+    }
+
+    @Test
+    fun clickImage_popBackStack() {
+        val navController = mock(NavController::class.java)
+
+        launchFragmentInHiltContainer<ImagePickFragment>(fragmentFactory = fragmentFactory) {
+            Navigation.setViewNavController(requireView(), navController)
+            imageAdapter.images = listOf(imageURL)
+        }
+
+        onView(withId(R.id.recyclerViewImages)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<ImageAdapter.ImageViewHolder>(0, click())
+        )
+
+        verify(navController).popBackStack()
+    }
+
+    @Test
+    fun clickImage_setImageURL() {
+        val navController = mock(NavController::class.java)
+        val testViewModel = ShoppingViewModel(
+            DefaultShoppingRepository(
+                FakeRemoteDataSourceAndroidTest(),
+                FakeLocalDataSourceAndroidTest()
+            )
+        )
+
+        launchFragmentInHiltContainer<ImagePickFragment>(fragmentFactory = fragmentFactory) {
+            Navigation.setViewNavController(requireView(), navController)
+            viewModel = testViewModel
+            imageAdapter.images = listOf(imageURL)
+        }
+
+        onView(withId(R.id.recyclerViewImages)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<ImageAdapter.ImageViewHolder>(0, click())
+        )
+
+        assertThat(testViewModel.currentImageUrl.getOrAwaitValue()).isEqualTo(imageURL)
+    }
+}
+
+```
+
+## Additional Information
+
+### Errors
+
+#### Espresso tests fail if another area is in focus
+
+```terminal
+clickAddShoppingItemButton_navigateToAddShoppingItemFragment(com.example.testapplication.ui.ShoppingFragmentTest)
+
+androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non default root matcher, it may be picking a root that never takes focus. Root:
+Root{application-window-token=android.view.ViewRootImpl$W@d5c5245, window-token=android.view.ViewRootImpl$W@d5c5245, has-window-focus=false, layout-params-type=1, layout-params-string={(0,0)(fillxfill) sim={forwardNavigation} ty=BASE_APPLICATION wanim=0x10302fe
+fl=LAYOUT_IN_SCREEN LAYOUT_INSET_DECOR SPLIT_TOUCH HARDWARE_ACCELERATED DRAWS_SYSTEM_BAR_BACKGROUNDS
+pfl=FORCE_DRAW_STATUS_BAR_BACKGROUND FIT_INSETS_CONTROLLED
+fitSides=}, decor-view-string=DecorView{id=-1, visibility=VISIBLE, width=1080, height=2340, has-focus=false, has-focusable=true, has-window-focus=false, is-clickable=false, is-enabled=true, is-focused=false, is-focusable=false, is-layout-requested=false, is-selected=false, layout-params={(0,0)(fillxfill) sim={forwardNavigation} ty=BASE_APPLICATION wanim=0x10302fe
+fl=LAYOUT_IN_SCREEN LAYOUT_INSET_DECOR SPLIT_TOUCH HARDWARE_ACCELERATED DRAWS_SYSTEM_BAR_BACKGROUNDS
+pfl=FORCE_DRAW_STATUS_BAR_BACKGROUND FIT_INSETS_CONTROLLED
+fitSides=}, tag=null, root-is-layout-requested=false, has-input-connection=false, x=0.0, y=0.0, child-count=3}}
+```
+
+### Screenshots
+
+### Links
+
+[RecyclerView]: <https://developer.android.com/reference/kotlin/androidx/recyclerview/widget/RecyclerView#presenting-dynamic-data> "Presenting Dynamic Data"
+
+[DiffUtil]: <https://developer.android.com/reference/kotlin/androidx/recyclerview/widget/DiffUtil> "DiffUtil"
+
+- [Presenting Dynamic Data:](https://developer.android.com/reference/kotlin/androidx/recyclerview/widget/RecyclerView#presenting-dynamic-data)
+- [DiffUtil:](https://developer.android.com/reference/kotlin/androidx/recyclerview/widget/DiffUtil)
+
+## Notes template
+
+```kotlin
+
+```
+
+```xml
+
+```
+
+![Text](./static/img/name.jpg)
+
+[y]
+[y]: <https://link.to.thing> "link title"
+
+[link title](https://link.to.thing)

--- a/notes/notes_Android_Testing_With_PL_8.md
+++ b/notes/notes_Android_Testing_With_PL_8.md
@@ -267,7 +267,7 @@ class HiltTestActivity : AppCompatActivity()
 - We can set the `FragmentFactory` we passed as an argument to the as the `supportFragmentManager.fragmentFactory`.
 - We instantiate the fragment, and attach arguments to it.
 - We use `beginTransaction` to launch our fragment with no tag.
-- We call the lambda function.
+- We call the lambda function. This will make sure that the `Fragment` passed to this extension function is available as `this` and any statements within `{}` are executed on it.
 
 ```kotlin
 
@@ -277,10 +277,12 @@ class HiltTestActivity : AppCompatActivity()
  * hosted at
  *      https://github.com/android/architecture-components-samples
  * Modifications copyright (C) 2023 Debabrata Bhattacharya:
- *      package declaration on line 233
- *      import on line 257
- *      argument addition on line 259
- *      code addition on line 276
+ *      package declaration on line 237
+ *      import on line 261
+ *      argument addition on line 263
+ *      argument data type change on line 265
+ *      code addition on line 279
+ *      data type cast on line 291
  */
 
 // ! The line immediately below this line has been modified
@@ -290,11 +292,11 @@ import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StyleRes
+import androidx.core.util.Preconditions
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.core.internal.deps.guava.base.Preconditions
 
 /**
  * launchFragmentInContainer from the androidx.fragment:fragment-testing library
@@ -311,7 +313,8 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
     @StyleRes themeResId: Int = androidx.fragment.testing.R.style.FragmentScenarioEmptyFragmentActivityTheme,
     // ! The line immediately below this line has been modified
     fragmentFactory: FragmentFactory? = null,
-    crossinline action: Fragment.() -> Unit = {}
+    // ! The line immediately below this line has been modified
+    crossinline action: T.() -> Unit = {}
 ) {
     val startActivityIntent = Intent.makeMainActivity(
         ComponentName(
@@ -336,7 +339,8 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
             .add(android.R.id.content, fragment, "")
             .commitNow()
 
-        fragment.action()
+        // ! The line immediately below this line has been modified
+        (fragment as T).action()
     }
 }
 

--- a/notes/notes_Licensing.md
+++ b/notes/notes_Licensing.md
@@ -20,7 +20,7 @@ Course URL: [Android Testing with PL](https://www.youtube.com/playlist?list=PLQk
 
 - Google has some files that we can use in projects compatible with Apache V2 license.
 - To use these files, it is necessary to comply with the requirements of the Apache License.
-- In `LICENSE`, add a pointer to the dependency's license within the distribution and a short note summarizing its licensing:
+- In `LICENSE`, at the end add a pointer to the dependency's license within the distribution and a short note summarizing its licensing:
 
 ```LICENSE
 This project repository contains files from the
@@ -30,6 +30,8 @@ Version 2.0, January 2004. This is hosted at
 For details see:
     app/src/androidTest/java/com/example/testapplication/LiveDataTestUtil.kt
     app/src/test/java/com/example/testapplication/LiveDataTestUtil.kt
+    app/src/androidTest/java/com/example/testapplication/HiltExtension.kt
+
 ```
 
 - Retain the copyright preamble in each file.
@@ -309,6 +311,305 @@ fun <T> LiveData<T>.getOrAwaitValue(
 
     @Suppress("UNCHECKED_CAST")
     return data as T
+}
+
+```
+
+- Repeat this for `app/src/androidTest/java/com/example/testapplication/HiltExtension.kt`.
+
+```kotlin
+// HiltExtension
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *                                  Apache License
+ *                           Version 2.0, January 2004
+ *                        http://www.apache.org/licenses/
+ *
+ *   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ *
+ *   1. Definitions.
+ *
+ *      "License" shall mean the terms and conditions for use, reproduction,
+ *      and distribution as defined by Sections 1 through 9 of this document.
+ *
+ *      "Licensor" shall mean the copyright owner or entity authorized by
+ *      the copyright owner that is granting the License.
+ *
+ *      "Legal Entity" shall mean the union of the acting entity and all
+ *      other entities that control, are controlled by, or are under common
+ *      control with that entity. For the purposes of this definition,
+ *      "control" means (i) the power, direct or indirect, to cause the
+ *      direction or management of such entity, whether by contract or
+ *      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+ *      outstanding shares, or (iii) beneficial ownership of such entity.
+ *
+ *      "You" (or "Your") shall mean an individual or Legal Entity
+ *      exercising permissions granted by this License.
+ *
+ *      "Source" form shall mean the preferred form for making modifications,
+ *      including but not limited to software source code, documentation
+ *      source, and configuration files.
+ *
+ *      "Object" form shall mean any form resulting from mechanical
+ *      transformation or translation of a Source form, including but
+ *      not limited to compiled object code, generated documentation,
+ *      and conversions to other media types.
+ *
+ *      "Work" shall mean the work of authorship, whether in Source or
+ *      Object form, made available under the License, as indicated by a
+ *      copyright notice that is included in or attached to the work
+ *      (an example is provided in the Appendix below).
+ *
+ *      "Derivative Works" shall mean any work, whether in Source or Object
+ *      form, that is based on (or derived from) the Work and for which the
+ *      editorial revisions, annotations, elaborations, or other modifications
+ *      represent, as a whole, an original work of authorship. For the purposes
+ *      of this License, Derivative Works shall not include works that remain
+ *      separable from, or merely link (or bind by name) to the interfaces of,
+ *      the Work and Derivative Works thereof.
+ *
+ *      "Contribution" shall mean any work of authorship, including
+ *      the original version of the Work and any modifications or additions
+ *      to that Work or Derivative Works thereof, that is intentionally
+ *      submitted to Licensor for inclusion in the Work by the copyright owner
+ *      or by an individual or Legal Entity authorized to submit on behalf of
+ *      the copyright owner. For the purposes of this definition, "submitted"
+ *      means any form of electronic, verbal, or written communication sent
+ *      to the Licensor or its representatives, including but not limited to
+ *      communication on electronic mailing lists, source code control systems,
+ *      and issue tracking systems that are managed by, or on behalf of, the
+ *      Licensor for the purpose of discussing and improving the Work, but
+ *      excluding communication that is conspicuously marked or otherwise
+ *      designated in writing by the copyright owner as "Not a Contribution."
+ *
+ *      "Contributor" shall mean Licensor and any individual or Legal Entity
+ *      on behalf of whom a Contribution has been received by Licensor and
+ *      subsequently incorporated within the Work.
+ *
+ *   2. Grant of Copyright License. Subject to the terms and conditions of
+ *      this License, each Contributor hereby grants to You a perpetual,
+ *      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *      copyright license to reproduce, prepare Derivative Works of,
+ *      publicly display, publicly perform, sublicense, and distribute the
+ *      Work and such Derivative Works in Source or Object form.
+ *
+ *   3. Grant of Patent License. Subject to the terms and conditions of
+ *      this License, each Contributor hereby grants to You a perpetual,
+ *      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ *      (except as stated in this section) patent license to make, have made,
+ *      use, offer to sell, sell, import, and otherwise transfer the Work,
+ *      where such license applies only to those patent claims licensable
+ *      by such Contributor that are necessarily infringed by their
+ *      Contribution(s) alone or by combination of their Contribution(s)
+ *      with the Work to which such Contribution(s) was submitted. If You
+ *      institute patent litigation against any entity (including a
+ *      cross-claim or counterclaim in a lawsuit) alleging that the Work
+ *      or a Contribution incorporated within the Work constitutes direct
+ *      or contributory patent infringement, then any patent licenses
+ *      granted to You under this License for that Work shall terminate
+ *      as of the date such litigation is filed.
+ *
+ *   4. Redistribution. You may reproduce and distribute copies of the
+ *      Work or Derivative Works thereof in any medium, with or without
+ *      modifications, and in Source or Object form, provided that You
+ *      meet the following conditions:
+ *
+ *      (a) You must give any other recipients of the Work or
+ *          Derivative Works a copy of this License; and
+ *
+ *      (b) You must cause any modified files to carry prominent notices
+ *          stating that You changed the files; and
+ *
+ *      (c) You must retain, in the Source form of any Derivative Works
+ *          that You distribute, all copyright, patent, trademark, and
+ *          attribution notices from the Source form of the Work,
+ *          excluding those notices that do not pertain to any part of
+ *          the Derivative Works; and
+ *
+ *      (d) If the Work includes a "NOTICE" text file as part of its
+ *          distribution, then any Derivative Works that You distribute must
+ *          include a readable copy of the attribution notices contained
+ *          within such NOTICE file, excluding those notices that do not
+ *          pertain to any part of the Derivative Works, in at least one
+ *          of the following places: within a NOTICE text file distributed
+ *          as part of the Derivative Works; within the Source form or
+ *          documentation, if provided along with the Derivative Works; or,
+ *          within a display generated by the Derivative Works, if and
+ *          wherever such third-party notices normally appear. The contents
+ *          of the NOTICE file are for informational purposes only and
+ *          do not modify the License. You may add Your own attribution
+ *          notices within Derivative Works that You distribute, alongside
+ *          or as an addendum to the NOTICE text from the Work, provided
+ *          that such additional attribution notices cannot be construed
+ *          as modifying the License.
+ *
+ *      You may add Your own copyright statement to Your modifications and
+ *      may provide additional or different license terms and conditions
+ *      for use, reproduction, or distribution of Your modifications, or
+ *      for any such Derivative Works as a whole, provided Your use,
+ *      reproduction, and distribution of the Work otherwise complies with
+ *      the conditions stated in this License.
+ *
+ *   5. Submission of Contributions. Unless You explicitly state otherwise,
+ *      any Contribution intentionally submitted for inclusion in the Work
+ *      by You to the Licensor shall be under the terms and conditions of
+ *      this License, without any additional terms or conditions.
+ *      Notwithstanding the above, nothing herein shall supersede or modify
+ *      the terms of any separate license agreement you may have executed
+ *      with Licensor regarding such Contributions.
+ *
+ *   6. Trademarks. This License does not grant permission to use the trade
+ *      names, trademarks, service marks, or product names of the Licensor,
+ *      except as required for reasonable and customary use in describing the
+ *      origin of the Work and reproducing the content of the NOTICE file.
+ *
+ *   7. Disclaimer of Warranty. Unless required by applicable law or
+ *      agreed to in writing, Licensor provides the Work (and each
+ *      Contributor provides its Contributions) on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *      implied, including, without limitation, any warranties or conditions
+ *      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+ *      PARTICULAR PURPOSE. You are solely responsible for determining the
+ *      appropriateness of using or redistributing the Work and assume any
+ *      risks associated with Your exercise of permissions under this License.
+ *
+ *   8. Limitation of Liability. In no event and under no legal theory,
+ *      whether in tort (including negligence), contract, or otherwise,
+ *      unless required by applicable law (such as deliberate and grossly
+ *      negligent acts) or agreed to in writing, shall any Contributor be
+ *      liable to You for damages, including any direct, indirect, special,
+ *      incidental, or consequential damages of any character arising as a
+ *      result of this License or out of the use or inability to use the
+ *      Work (including but not limited to damages for loss of goodwill,
+ *      work stoppage, computer failure or malfunction, or any and all
+ *      other commercial damages or losses), even if such Contributor
+ *      has been advised of the possibility of such damages.
+ *
+ *   9. Accepting Warranty or Additional Liability. While redistributing
+ *      the Work or Derivative Works thereof, You may choose to offer,
+ *      and charge a fee for, acceptance of support, warranty, indemnity,
+ *      or other liability obligations and/or rights consistent with this
+ *      License. However, in accepting such obligations, You may act only
+ *      on Your own behalf and on Your sole responsibility, not on behalf
+ *      of any other Contributor, and only if You agree to indemnify,
+ *      defend, and hold each Contributor harmless for any liability
+ *      incurred by, or claims asserted against, such Contributor by reason
+ *      of your accepting any such warranty or additional liability.
+ *
+ *   END OF TERMS AND CONDITIONS
+ *
+ *   APPENDIX: How to apply the Apache License to your work.
+ *
+ *      To apply the Apache License to your work, attach the following
+ *      boilerplate notice, with the fields enclosed by brackets "[]"
+ *      replaced with your own identifying information. (Don't include
+ *      the brackets!)  The text should be enclosed in the appropriate
+ *      comment syntax for the file format. We also recommend that a
+ *      file or class name and description of purpose be included on the
+ *      same "printed page" as the copyright notice for easier
+ *      identification within third-party archives.
+ *
+ *   Copyright 2014 The Android Open Source Project
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/*
+ * Taken from the android/architecture-components-samples repository
+ * under the Apache License, Version 2.0, January 2004
+ * hosted at
+ *      https://github.com/android/architecture-components-samples
+ * Modifications copyright (C) 2023 Debabrata Bhattacharya:
+ *      package declaration on line 237
+ *      import on line 261
+ *      argument addition on line 263
+ *      argument data type change on line 265
+ *      code addition on line 279
+ *      data type cast on line 291
+ */
+
+// ! The line immediately below this line has been modified
+package com.example.testapplication
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import androidx.annotation.StyleRes
+import androidx.core.util.Preconditions
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+
+/**
+ * launchFragmentInContainer from the androidx.fragment:fragment-testing library
+ * is NOT possible to use right now as it uses a hardcoded Activity under the hood
+ * (i.e. [EmptyFragmentActivity]) which is not annotated with @AndroidEntryPoint.
+ *
+ * As a workaround, use this function that is equivalent. It requires you to add
+ * [HiltTestActivity] in the debug folder and include it in the debug AndroidManifest.xml file
+ * as can be found in this project.
+ */
+inline fun <reified T : Fragment> launchFragmentInHiltContainer(
+    fragmentArgs: Bundle? = null,
+    // ! The line immediately below this line has been modified
+    @StyleRes themeResId: Int = androidx.fragment.testing.R.style.FragmentScenarioEmptyFragmentActivityTheme,
+    // ! The line immediately below this line has been modified
+    fragmentFactory: FragmentFactory? = null,
+    // ! The line immediately below this line has been modified
+    crossinline action: T.() -> Unit = {}
+) {
+    val startActivityIntent = Intent.makeMainActivity(
+        ComponentName(
+            ApplicationProvider.getApplicationContext(),
+            HiltTestActivity::class.java
+        )
+    ).putExtra(
+        "androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity.THEME_EXTRAS_BUNDLE_KEY",
+        themeResId
+    )
+
+    ActivityScenario.launch<HiltTestActivity>(startActivityIntent).onActivity { activity ->
+        // ! The line immediately below this line has been modified
+        fragmentFactory?.let { activity.supportFragmentManager.fragmentFactory = it }
+        val fragment: Fragment = activity.supportFragmentManager.fragmentFactory.instantiate(
+            Preconditions.checkNotNull(T::class.java.classLoader),
+            T::class.java.name
+        )
+        fragment.arguments = fragmentArgs
+        activity.supportFragmentManager
+            .beginTransaction()
+            .add(android.R.id.content, fragment, "")
+            .commitNow()
+
+        // ! The line immediately below this line has been modified
+        (fragment as T).action()
+    }
 }
 
 ```


### PR DESCRIPTION
Add code and notes for testing `ui/ImagePickFragment.kt` with Mockito, espresso, and Dagger-Hilt.

This includes the following actions:

- create new notes file `notes_Android_Testing_With_PL_10.md`.
- update android application and library gradle plugins from `8.2.1` to `8.2.2`.
- add provider for Glide instance and create `GlideModule` class.
- create an adapter `ImageAdapter` for the RecycleView items in `ImagePickFragment.kt`.
- create a `FragmentFactory` at `ShoppingFragmentFactory`.
- setup `ImagePickFragment`.
- update `LICENSE` and notes.
- `.idea` automated cleanup.
- fix(test): `launchFragmentInHiltContainer` has incorrect type for argument `action`. `launchFragmentInHiltContainer` has an incorrect type `Fragment.()` for argument `action` instead of `T.()`. This means that the lambda function `action` will operate on an instance of `Fragment` instead of the fragment container passed as `T`.
- add test to check if pressing back button sets a blank url in `AddShoppingItemFragmentTest.kt`
- add `FakeLocalDataSourceAndroidTest` and `FakeRemoteDataSourceAndroidTest` to the `androidTest` sourceset.
- add `androidx.test.espresso:espresso-contrib` and `com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework` to `app/build.gradle.kts`.
- add `INTERNET` permission to `AndroidManifest.xml`.